### PR TITLE
Remove pod_spec from stored_state

### DIFF
--- a/opslib/osm/charm.py
+++ b/opslib/osm/charm.py
@@ -23,6 +23,8 @@
 __all__ = ["CharmedOsmBase", "RelationsMissing"]
 
 
+import hashlib
+import json
 import logging
 from typing import Any, Dict, NoReturn
 
@@ -97,6 +99,13 @@ class CharmedOsmBase(CharmBase):
             self.unit.status = BlockedStatus(e)
 
     def _set_pod_spec(self, pod_spec: Dict[str, Any]) -> NoReturn:
-        if self.state.pod_spec != pod_spec:
+        pod_spec_hash = _hash_from_dict(pod_spec)
+        if self.state.pod_spec != pod_spec_hash:
             self.model.pod.set_spec(pod_spec)
-            self.state.pod_spec = pod_spec
+            self.state.pod_spec = pod_spec_hash
+
+
+def _hash_from_dict(dict: Dict[str, Any]) -> str:
+    dict_str = json.dumps(dict, sort_keys=True)
+    result = hashlib.md5(dict_str.encode())
+    return result.hexdigest()

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,15 @@
+import sys
+
+
+import mock
+
+
+class OCIImageResourceErrorMock(Exception):
+    pass
+
+
+sys.path.append("src")
+
+oci_image = mock.MagicMock()
+oci_image.OCIImageResourceError = OCIImageResourceErrorMock
+sys.modules["oci_image"] = oci_image

--- a/tests/test_charm.py
+++ b/tests/test_charm.py
@@ -1,3 +1,42 @@
-# import unittest
+#!/usr/bin/env python3
 
-# from opslib.osm.charm import CharmedOsmBase
+import base64
+import sys
+from typing import NoReturn
+import unittest
+
+import mock
+from opslib.osm.charm import CharmedOsmBase
+from ops.model import ActiveStatus, WaitingStatus
+from ops.testing import Harness
+
+
+class TestCharm(unittest.TestCase):
+    """Prometheus Charm unit tests."""
+
+    def setUp(self) -> NoReturn:
+        """Test setup"""
+        self.image_info = sys.modules["oci_image"].OCIImageResource().fetch()
+        self.harness = Harness(CharmedOsmBase)
+        self.harness.set_leader(is_leader=True)
+        self.harness.begin()
+
+    def test_config_changed_non_leader(
+        self,
+    ) -> NoReturn:
+        self.harness.set_leader(is_leader=False)
+        self.harness.charm.on.config_changed.emit()
+        self.assertIsInstance(self.harness.charm.unit.status, ActiveStatus)
+
+    @mock.patch("opslib.osm.charm.CharmedOsmBase.build_pod_spec")
+    def test_config_changed_leader(self, mock_build_pod_spec) -> NoReturn:
+        mock_build_pod_spec.return_value = {
+            "version": 3,
+            "containers": [{"name": "c1"}, {"name": "c2"}],
+        }
+        self.harness.charm.on.config_changed.emit()
+        self.assertIsInstance(self.harness.charm.unit.status, ActiveStatus)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The stored state has a maximum length of 65536 chars, which may cause
problems in some cases.

Added unit tests for the base charm