### PR TITLE
Fix exception in charm

### DIFF
--- a/opslib/osm/charm.py
+++ b/opslib/osm/charm.py
@@ -94,8 +94,9 @@ class CharmedOsmBase(CharmBase):
         except ModelError as e:
             self.unit.status = BlockedStatus(str(e))
         except Exception as e:
-            logger.error(f"Unknown exception: {e}")
-            self.unit.status = BlockedStatus(e.message)
+            error_message = f"Unknown exception: {e}"
+            logger.error(error_message)
+            self.unit.status = BlockedStatus(error_message)
 
     def _set_pod_spec(self, pod_spec: Dict[str, Any]) -> NoReturn:
         pod_spec_hash = _hash_from_dict(pod_spec)


### PR DESCRIPTION
I introduced and error in PR#4, Exception does not have a message
attribute. This patch fixes that and achieves what was intended in the
previous PR