### PR TITLE
Providing error string to NotImplementedError in base charm

### DIFF
--- a/opslib/osm/charm.py
+++ b/opslib/osm/charm.py
@@ -71,7 +71,7 @@ class CharmedOsmBase(CharmBase):
         self.framework.observe(self.on.leader_elected, self.configure_pod)
 
     def build_pod_spec(self, image_info):
-        raise NotImplementedError()
+        raise NotImplementedError("build_pod_spec is not implemented")
 
     def configure_pod(self, _=None) -> NoReturn:
         """Assemble the pod spec and apply it, if possible."""

--- a/opslib/osm/interfaces/prometheus.py
+++ b/opslib/osm/interfaces/prometheus.py
@@ -22,6 +22,7 @@ charms at https://git.launchpad.net/canonical-osm
 """
 
 from typing import NoReturn
+
 import ops.charm
 import ops.framework
 import ops.model
@@ -86,6 +87,7 @@ class PrometheusScrapeTarget(ops.framework.Object):
                 relation.data[self.framework.model.app]["metrics_path"] = metrics_path
                 relation.data[self.framework.model.app]["scrape_interval"] = scrape_interval
                 relation.data[self.framework.model.app]["scrape_timeout"] = scrape_timeout
+
 
 class PrometheusScrapeServer(BaseRelationClient):
     """Requires side of a Prometheus Scrape Endpoint"""


### PR DESCRIPTION
There needs to be a string as a message in that exception.
Eases the debugging.